### PR TITLE
feat(compositor): Track and apply layer shell exclusive zones

### DIFF
--- a/sc_config.example.toml
+++ b/sc_config.example.toml
@@ -24,6 +24,15 @@ keyboard_repeat_delay = 300
 keyboard_repeat_rate = 30
 natural_scroll = true
 
+# Layer shell (panels, bars, overlays)
+[layer_shell]
+# Maximum exclusive zone per edge in logical points (0 = unlimited)
+# These values are multiplied by screen_scale to get physical pixels
+max_top = 100       # Top panels/bars
+max_bottom = 100    # Bottom panels/docks
+max_left = 50       # Left side panels
+max_right = 50      # Right side panels
+
 # Apps
 terminal_bin = "weston-terminal"
 file_manager_bin = "dolphin"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,8 +27,8 @@ pub struct Config {
     pub cursor_size: u32,
     pub natural_scroll: bool,
     #[serde(default)]
-    pub dock: DockConfig,
-    pub terminal_bin: String,
+    pub dock: DockConfig,    #[serde(default)]
+    pub layer_shell: LayerShellConfig,    pub terminal_bin: String,
     pub file_manager_bin: String,
     pub browser_bin: String,
     pub browser_args: Vec<String>,
@@ -65,6 +65,7 @@ impl Default for Config {
             cursor_size: 24,
             natural_scroll: true,
             dock: DockConfig::default(),
+            layer_shell: LayerShellConfig::default(),
             terminal_bin: "kitty".to_string(),
             file_manager_bin: "dolphin".to_string(),
             browser_bin: "firefox".to_string(),
@@ -312,6 +313,49 @@ pub struct DockConfig {
     pub genie_span: f64,
     #[serde(default)]
     pub bookmarks: Vec<DockBookmark>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerShellConfig {
+    /// Maximum exclusive zone allowed for top edge in logical points (0 = unlimited)
+    #[serde(default = "default_max_top")]
+    pub max_top: i32,
+    /// Maximum exclusive zone allowed for bottom edge in logical points (0 = unlimited)
+    #[serde(default = "default_max_bottom")]
+    pub max_bottom: i32,
+    /// Maximum exclusive zone allowed for left edge in logical points (0 = unlimited)
+    #[serde(default = "default_max_left")]
+    pub max_left: i32,
+    /// Maximum exclusive zone allowed for right edge in logical points (0 = unlimited)
+    #[serde(default = "default_max_right")]
+    pub max_right: i32,
+}
+
+impl Default for LayerShellConfig {
+    fn default() -> Self {
+        Self {
+            max_top: default_max_top(),
+            max_bottom: default_max_bottom(),
+            max_left: default_max_left(),
+            max_right: default_max_right(),
+        }
+    }
+}
+
+fn default_max_top() -> i32 {
+    100 // Max 100 logical points for top panels
+}
+
+fn default_max_bottom() -> i32 {
+    100 // Max 100 logical points for bottom panels/docks
+}
+
+fn default_max_left() -> i32 {
+    50 // Max 50 logical points for side panels
+}
+
+fn default_max_right() -> i32 {
+    50 // Max 50 logical points for side panels
 }
 
 fn default_dock_size() -> f64 {


### PR DESCRIPTION
Implements proper exclusive zone tracking for layer shell surfaces to reserve screen space on each output edge. This ensures that maximized windows and other compositor features respect the space reserved by panels, docks, and other layer shell surfaces.

Features:
- ExclusiveZones struct tracking reserved space per output edge
- recalculate_exclusive_zones() method to compute zones from layer surfaces
- Automatic recalculation on layer surface creation and destruction
- Configurable max limits per edge (top, bottom, left, right)
- Respects layer shell anchor and exclusive zone values
- Integration with window maximize to use available space

Changes:
- Added exclusive_zones HashMap to ScreenComposer state
- Layer surfaces trigger zone recalculation on map/unmap
- Maximize uses tracked zones instead of hardcoded top bar
- New config options for max exclusive zone limits
- Proper cloning to avoid borrow conflicts

This fixes the issue where maximized windows would overlap layer shell surfaces like top bars and docks.