### PR TITLE
fix: update puffin_http to 0.16 for compatibility with puffin 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tracing = { version = "0.1.37", features = [
     "release_max_level_debug",
 ] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-puffin_http = { version = "0.13", optional = true }
+puffin_http = { version = "0.16", optional = true }
 profiling = { version = "1.0" }
 renderdoc = { version = "0.11.0", optional = true }
 serde = "1.0.213"

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
     profiling::register_thread!("Main Thread");
 
     #[cfg(feature = "profile-with-puffin")]
-    let _server = puffin_http::Server::new(&format!("0.0.0.0:{}", puffin_http::DEFAULT_PORT)); //.unwrap();
+    let _server = puffin_http::Server::new(&format!("0.0.0.0:{}", puffin_http::DEFAULT_PORT)).unwrap();
     #[cfg(feature = "profile-with-puffin")]
     profiling::puffin::set_scopes_on(true);
 


### PR DESCRIPTION
- Upgrade puffin_http from 0.13 to 0.16 to match puffin version used by profiling crate
- Uncomment .unwrap() on puffin server initialization to catch startup errors
- Fixes version mismatch causing puffin_viewer connection resets