### PR TITLE
feat: configurable accent color!

### DIFF
--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -12,6 +12,10 @@ theme_scheme = "Light"  # "Light" or "Dark" - exposed via XDG Desktop Portal Set
 # background_image = "/usr/share/otto/background.jpg"
 background_color = "#2c2ca0"  # Fallback gradient color (bottom) when background_image is unavailable
 
+# Accent color for workspace and window selector borders
+# Available colors: red, orange, yellow, green, mint, teal, cyan, blue, indigo, purple, pink, gray, brown
+accent_color = "blue"
+
 # Inputs
 keyboard_repeat_delay = 300
 keyboard_repeat_rate = 30

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,6 +37,8 @@ pub struct Config {
     pub background_color: String,
     pub locales: Vec<String>,
     pub use_10bit_color: bool,
+    #[serde(default = "default_accent_color")]
+    pub accent_color: String,
     #[serde(default = "shortcuts::default_shortcut_map")]
     pub keyboard_shortcuts: ShortcutMap,
     #[serde(skip)]
@@ -66,6 +68,7 @@ impl Default for Config {
             background_color: "#1a1a2e".to_string(),
             locales: vec!["en".to_string()],
             use_10bit_color: false,
+            accent_color: default_accent_color(),
             keyboard_shortcuts: shortcuts::default_shortcut_map(),
             shortcut_bindings: Vec::new(),
         };
@@ -309,6 +312,10 @@ fn default_genie_scale() -> f64 {
 
 fn default_genie_span() -> f64 {
     10.0
+}
+
+fn default_accent_color() -> String {
+    "blue".to_string()
 }
 
 /// Input device configuration

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -130,3 +130,26 @@ pub fn theme_colors() -> &'static Lazy<ThemeColors> {
         ThemeScheme::Dark => &colors_dark::COLORS,
     })
 }
+
+/// Get the configured accent color by name
+pub fn accent_color() -> Color {
+    let colors = theme_colors();
+    Config::with(|c| {
+        match c.accent_color.as_str() {
+            "red" => colors.accents_red,
+            "orange" => colors.accents_orange,
+            "yellow" => colors.accents_yellow,
+            "green" => colors.accents_green,
+            "mint" => colors.accents_mint,
+            "teal" => colors.accents_teal,
+            "cyan" => colors.accents_cyan,
+            "blue" => colors.accents_blue,
+            "indigo" => colors.accents_indigo,
+            "purple" => colors.accents_purple,
+            "pink" => colors.accents_pink,
+            "gray" => colors.accents_gray,
+            "brown" => colors.accents_brown,
+            _ => colors.accents_blue, // default fallback
+        }
+    })
+}

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -16,7 +16,6 @@ use std::{
 use crate::{
     config::Config,
     interactive_view::ViewInteractions,
-    theme::theme_colors,
     utils::natural_layout::{natural_layout, LayoutRect},
 };
 
@@ -541,10 +540,10 @@ pub fn view_window_selector(
     let draw_container = Some(move |canvas: &skia::Canvas, w, h| {
         if window_selection.is_some() {
             let window_selection = window_selection.as_ref().unwrap();
-            let color = theme_colors().accents_blue.c4f();
+            let color = crate::theme::accent_color().c4f();
             let mut paint = skia::Paint::new(color, None);
             paint.set_stroke(true);
-            paint.set_stroke_width(12.0 * draw_scale);
+            paint.set_stroke_width(8.0 * draw_scale);
             let rrect = skia::RRect::new_rect_xy(
                 skia::Rect::from_xywh(
                     window_selection.x,
@@ -552,9 +551,9 @@ pub fn view_window_selector(
                     window_selection.w,
                     window_selection.h,
                 )
-                .with_outset((draw_scale * 6.0, draw_scale * 6.0)),
-                12.0 * draw_scale,
-                12.0 * draw_scale,
+                .with_outset((draw_scale * 8.0, draw_scale * 8.0)),
+                16.0 * draw_scale,
+                16.0 * draw_scale,
             );
 
             canvas.draw_rrect(rrect, &paint);

--- a/src/workspaces/workspace_selector.rs
+++ b/src/workspaces/workspace_selector.rs
@@ -182,7 +182,7 @@ fn render_workspace_selector_view(
             let is_drop_hover = state_drop_hover_index - 1 == (i as i32) && !current;
 
             let mut border_width = 0.0;
-            let border_color = theme_colors().accents_blue;
+            let border_color = crate::theme::accent_color();
 
             if current {
                 border_width = 8.0;


### PR DESCRIPTION
this PR makes the accent color used in some of the elements of the UI configurable.
it supports named colors available in the theme configured
```toml
accent_color = "blue"
```

```rust
Config::with(|c| {
        match c.accent_color.as_str() {
            "red" => colors.accents_red,
            "orange" => colors.accents_orange,
            "yellow" => colors.accents_yellow,
            "green" => colors.accents_green,
            "mint" => colors.accents_mint,
            "teal" => colors.accents_teal,
            "cyan" => colors.accents_cyan,
            "blue" => colors.accents_blue,
            "indigo" => colors.accents_indigo,
            "purple" => colors.accents_purple,
            "pink" => colors.accents_pink,
            "gray" => colors.accents_gray,
            "brown" => colors.accents_brown,
            _ => colors.accents_blue, // default fallback
        }
    })
```