### PR TITLE
fix: wlr layer popup focus

### DIFF
--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -241,7 +241,23 @@ impl<BackendData: Backend> Otto<BackendData> {
             .or_else(|| layers.layer_under(WlrLayer::Top, pos))
         {
             let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-            under = Some((layer.clone().into(), output_geo.loc + layer_loc));
+            let layer_abs_pos = output_geo.loc + layer_loc;
+            
+            // Check for surfaces under this layer (including popups)
+            // Pass position relative to layer surface
+            if let Some((surface, surface_loc)) = layer.surface_under(
+                pos - layer_abs_pos.to_f64(),
+                WindowSurfaceType::ALL,
+            ) {
+                // surface_loc is relative to layer surface, convert to absolute
+                under = Some((
+                    PointerFocusTarget::WlSurface(surface),
+                    layer_abs_pos + surface_loc,
+                ));
+            } else {
+                // No popup, use the layer surface itself
+                under = Some((layer.clone().into(), layer_abs_pos));
+            }
         }
         // Check dock
         else if self
@@ -272,7 +288,23 @@ impl<BackendData: Backend> Otto<BackendData> {
             .or_else(|| layers.layer_under(WlrLayer::Background, pos))
         {
             let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-            under = Some((layer.clone().into(), output_geo.loc + layer_loc));
+            let layer_abs_pos = output_geo.loc + layer_loc;
+            
+            // Check for surfaces under this layer (including popups)
+            // Pass position relative to layer surface
+            if let Some((surface, surface_loc)) = layer.surface_under(
+                pos - layer_abs_pos.to_f64(),
+                WindowSurfaceType::ALL,
+            ) {
+                // surface_loc is relative to layer surface, convert to absolute
+                under = Some((
+                    PointerFocusTarget::WlSurface(surface),
+                    layer_abs_pos + surface_loc,
+                ));
+            } else {
+                // No popup, use the layer surface itself
+                under = Some((layer.clone().into(), layer_abs_pos));
+            }
         };
         under.map(|(s, l)| (s, l.to_f64()))
     }

--- a/src/workspaces/popup_overlay.rs
+++ b/src/workspaces/popup_overlay.rs
@@ -102,7 +102,18 @@ impl PopupOverlayView {
     ) -> HashMap<ObjectId, Layer> {
         let popup =
             self.get_or_create_popup_layer(popup_id.clone(), root_window_id.clone(), warm_cache);
-        popup.layer.set_position(position, None);
+        
+        // Account for the layer's size and anchor point when positioning
+        // The position parameter represents where we want the top-left corner to be,
+        // but set_position places the layer's anchor point at that position.
+        // So we need to offset by (size * anchor_point) to get the correct visual position.
+        let anchor_point = popup.layer.anchor_point();
+        let size = popup.layer.render_size();
+        let adjusted_position = Point {
+            x: position.x + (size.x * anchor_point.x),
+            y: position.y + (size.y * anchor_point.y),
+        };
+        popup.layer.set_position(adjusted_position, None);
 
         // Map surface IDs to their layers
         let mut surface_layers: HashMap<ObjectId, Layer> = HashMap::new();

--- a/src/workspaces/utils/mod.rs
+++ b/src/workspaces/utils/mod.rs
@@ -175,7 +175,6 @@ pub fn configure_surface_layer(layer: &Layer, wvs: &WindowViewSurface) {
         ..Default::default()
     });
 
-    layer.set_position(Point { x: pos_x, y: pos_y }, None);
     layer.set_size(
         Size {
             width: taffy::Dimension::Length(wvs.phy_dst_w),
@@ -183,6 +182,16 @@ pub fn configure_surface_layer(layer: &Layer, wvs: &WindowViewSurface) {
         },
         None,
     );
+
+    // Account for the layer's anchor point when positioning
+    // set_position places the anchor point at the given coordinates,
+    // so we need to offset by (size * anchor_point) to get the desired visual position
+    let anchor_point = layer.anchor_point();
+    let adjusted_pos = Point {
+        x: pos_x + (wvs.phy_dst_w * anchor_point.x),
+        y: pos_y + (wvs.phy_dst_h * anchor_point.y),
+    };
+    layer.set_position(adjusted_pos, None);
 
     layer.set_pointer_events(false);
     layer.set_picture_cached(true); // Enable picture caching for proper opacity inheritance


### PR DESCRIPTION
# FIX: Wlr layer's popus

This PR fixes handling of wlr layer popup surfaces to ensure they are properly managed and can receive focus.

This resolves an issue where popups were created but not focusable, leading to broken interactions in layer surfaces.