### PR TITLE
feat(multi-monitor): per-output independent workspace sets (wip)

### DIFF
--- a/components/otto-kit/src/surfaces/layer_shell.rs
+++ b/components/otto-kit/src/surfaces/layer_shell.rs
@@ -160,10 +160,7 @@ impl LayerShellSurface {
         AppContext::register_layer_configure_callback(
             layer_surface_id,
             move |width, height, serial| {
-                println!(
-                    "Layer configure callback: {}x{}, serial: {}",
-                    width, height, serial
-                );
+                tracing::debug!("Layer configure callback: {}x{}, serial: {}", width, height, serial);
 
                 // Extract callback before borrowing to avoid double borrow
                 let callback_to_call = {

--- a/scripts/test-screenshare.sh
+++ b/scripts/test-screenshare.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE="org.otto.ScreenCast"
+ROOT_PATH="/org/otto/ScreenCast"
+ROOT_IFACE="org.otto.ScreenCast"
+SESSION_IFACE="org.otto.ScreenCast.Session"
+
+OUTPUT="${1:-eDP-1}"
+OPEN_PIPEWIRE="${OPEN_PIPEWIRE:-0}"
+PLAYER="${PLAYER:-gst}" # gst|ffplay|none
+CLEANED_UP=0
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+extract_object_path() {
+    awk -F'"' '{print $2}'
+}
+
+require_cmd busctl
+require_cmd awk
+require_cmd grep
+
+echo "Listing outputs..."
+OUTPUTS_RAW="$(busctl --user call "$SERVICE" "$ROOT_PATH" "$ROOT_IFACE" ListOutputs)"
+echo "  $OUTPUTS_RAW"
+
+if ! grep -q "\"$OUTPUT\"" <<<"$OUTPUTS_RAW"; then
+    echo "Output '$OUTPUT' not found. Pick one from the list above." >&2
+    exit 1
+fi
+
+echo "Creating session..."
+SESSION_PATH="$(
+    busctl --user call "$SERVICE" "$ROOT_PATH" "$ROOT_IFACE" CreateSession a{sv} 0 \
+        | extract_object_path
+)"
+echo "  session: $SESSION_PATH"
+
+cleanup() {
+    if [[ "$CLEANED_UP" == "1" ]]; then
+        return
+    fi
+    CLEANED_UP=1
+
+    if [[ -n "${SESSION_PATH:-}" ]]; then
+        echo
+        echo "Stopping session..."
+        busctl --user call "$SERVICE" "$SESSION_PATH" "$SESSION_IFACE" Stop >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+echo "Recording monitor '$OUTPUT'..."
+STREAM_PATH="$(
+    busctl --user call "$SERVICE" "$SESSION_PATH" "$SESSION_IFACE" RecordMonitor sa{sv} "$OUTPUT" 0 \
+        | extract_object_path
+)"
+echo "  stream: $STREAM_PATH"
+
+echo "Starting session..."
+busctl --user call "$SERVICE" "$SESSION_PATH" "$SESSION_IFACE" Start
+echo "Session started."
+
+if [[ "$OPEN_PIPEWIRE" == "1" ]]; then
+    echo "Opening PipeWire remote..."
+    busctl --user call "$SERVICE" "$SESSION_PATH" "$SESSION_IFACE" OpenPipeWireRemote a{sv} 0
+fi
+
+echo "Reading stream metadata..."
+NODE="$(
+    busctl --user call "$SERVICE" "$STREAM_PATH" org.otto.ScreenCast.Stream PipeWireNode \
+        | awk '{print $NF}'
+)"
+echo "  node-id: $NODE"
+busctl --user call "$SERVICE" "$STREAM_PATH" org.otto.ScreenCast.Stream Metadata
+
+case "$PLAYER" in
+    none)
+        echo "Press Ctrl+C to stop."
+        while true; do
+            sleep 1
+        done
+        ;;
+    gst)
+        require_cmd gst-launch-1.0
+        for sink in waylandsink autovideosink ximagesink glimagesink; do
+            echo "Opening stream with GStreamer (sink: $sink)..."
+            set +e
+            gst-launch-1.0 pipewiresrc path="$NODE" do-timestamp=true ! videoconvert ! queue ! "$sink" sync=false
+            status=$?
+            set -e
+            if [[ "$status" -eq 0 ]]; then
+                break
+            fi
+            if [[ "$status" -eq 130 ]]; then
+                exit 130
+            fi
+            echo "Sink failed: $sink"
+        done
+        ;;
+    ffplay)
+        require_cmd ffplay
+        echo "Opening stream with ffplay..."
+        ffplay -f pipewire -i "$NODE"
+        ;;
+    *)
+        echo "Invalid PLAYER value '$PLAYER'. Use one of: none, gst, ffplay" >&2
+        exit 1
+        ;;
+esac

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -276,7 +276,9 @@ impl<BackendData: Backend> Otto<BackendData> {
         }
         // Window selector check
         if self.workspaces.get_show_all() {
-            let workspace = self.workspaces.get_current_workspace();
+            let Some(workspace) = self.workspaces.get_current_workspace() else {
+                return None;
+            };
             let focus = workspace.window_selector_view.as_ref().clone().into();
             let position = workspace.window_selector_view.layer.render_position();
 
@@ -435,6 +437,12 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
         let pointer = self.pointer.clone();
         // Cache pointer location for use in button events
         self.last_pointer_location = (pos.x, pos.y);
+
+        // Update focused output for workspace selector display
+        {
+            let focused = self.workspaces.output_under(pos).next().cloned();
+            self.workspaces.set_focused_output(focused.as_ref());
+        }
 
         pointer.motion(
             self,

--- a/src/screenshare/pipewire_stream.rs
+++ b/src/screenshare/pipewire_stream.rs
@@ -226,7 +226,7 @@ impl PipeWireStream {
             unsafe {
                 pipewire::sys::pw_stream_trigger_process(ptr);
             }
-            tracing::debug!("Triggered pw_stream_trigger_process");
+            tracing::trace!("Triggered pw_stream_trigger_process");
         } else {
             tracing::warn!("trigger_frame called but stream_ptr not set");
         }

--- a/src/winit.rs
+++ b/src/winit.rs
@@ -367,6 +367,9 @@ pub fn run_winit() {
         .shm_state
         .update_formats(state.backend_data.backend.renderer().shm_formats());
 
+    // Set initial screen dimensions before mapping output so update_workspaces_layout
+    // can compute the correct scene size.
+    state.workspaces.set_screen_dimension(size.w, size.h);
     state.workspaces.map_output(&output, (0, 0));
 
     #[cfg(feature = "xwayland")]
@@ -414,12 +417,9 @@ pub fn run_winit() {
                 output.set_preferred(mode);
                 let pointer_location = state.pointer.current_location();
                 crate::shell::fixup_positions(&mut state.workspaces, pointer_location);
-                state.scene_element.set_size(size.w as f32, size.h as f32);
+                // set_screen_dimension triggers update_workspaces_layout which resizes
+                // the scene root to cover all outputs' physical extents.
                 state.workspaces.set_screen_dimension(size.w, size.h);
-                root.set_size(
-                    layers::types::Size::points(size.w as f32, size.h as f32),
-                    None,
-                );
             }
             WinitEvent::Input(event) => state.process_input_event_windowed(event, OUTPUT_NAME),
             _ => (),

--- a/src/workspaces/app_switcher/view.rs
+++ b/src/workspaces/app_switcher/view.rs
@@ -102,7 +102,6 @@ impl AppSwitcherView {
         });
         apps_container.set_pointer_events(false);
 
-        layers_engine.add_layer(&wrap);
         wrap.add_sublayer(&panel);
         panel.add_sublayer(&apps_container);
 

--- a/src/workspaces/dnd_view.rs
+++ b/src/workspaces/dnd_view.rs
@@ -22,8 +22,7 @@ impl DndView {
             ..Default::default()
         });
 
-        layers_engine.add_layer(&layer);
-        layers_engine.append_layer(&content_layer, layer.id());
+        layer.add_sublayer(&content_layer);
 
         Self {
             layer,

--- a/src/workspaces/osd.rs
+++ b/src/workspaces/osd.rs
@@ -62,7 +62,6 @@ impl OsdView {
 
         // Create inner view layer
         let layer = layers_engine.new_layer();
-        layers_engine.add_layer(&wrap);
         wrap.add_sublayer(&layer);
         layer.set_opacity(0.0, None);
         layer.set_pointer_events(false);

--- a/src/workspaces/popup_overlay.rs
+++ b/src/workspaces/popup_overlay.rs
@@ -41,7 +41,6 @@ impl PopupOverlayView {
         });
         layer.set_pointer_events(false);
 
-        layers_engine.add_layer(&layer);
 
         Self {
             layer,

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -391,7 +391,8 @@ impl WindowSelectorView {
         if otto
             .workspaces
             .get_current_workspace()
-            .get_fullscreen_mode()
+            .map(|w| w.get_fullscreen_mode())
+            .unwrap_or(false)
         {
             return None;
         }
@@ -403,8 +404,8 @@ impl WindowSelectorView {
             let window_in_space = otto
                 .workspaces
                 .space()
-                .elements()
-                .any(|w| w.id() == *window_id);
+                .map(|s| s.elements().any(|w| w.id() == *window_id))
+                .unwrap_or(false);
 
             if !window_in_space {
                 return None;
@@ -925,7 +926,7 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for WindowSelecto
                                 let position = otto
                                     .workspaces
                                     .space()
-                                    .element_location(&window_element)
+                                    .and_then(|s| s.element_location(&window_element))
                                     .unwrap_or_default();
 
                                 // Clear dragging state


### PR DESCRIPTION
Each physical or virtual output now has its own OutputWorkspaces containing its own workspaces_layer, Vec<Space>, and workspace views. Outputs switch workspaces independently via set_workspace_for_output().

- Add OutputWorkspaces struct with current_workspace, spaces, workspaces_layer, workspace_views per output
- Replace Workspaces.spaces + Workspaces.workspaces_layer with
  output_workspaces: HashMap<String, OutputWorkspaces>
- map_output_with_primary() creates a full workspace set for each output
- unmap_output() tears down the output's workspace set
- add_workspace() adds a slot to every output's workspace set
- add set_workspace_for_output() for per-output independent switching
- set_current_workspace_index() in state now uses output_under(pointer) to target the output under the cursor