### PR TITLE
fix(screencopy): complete captures on an idle screen

### DIFF
--- a/src/state/screencopy.rs
+++ b/src/state/screencopy.rs
@@ -266,6 +266,15 @@ where
                 // Wake the render loop — the compositor may be idle with no pending
                 // damage, so `should_draw` would normally be false and screencopy
                 // would never be fulfilled without this kick.
+                //
+                // Waking is not enough on its own: the copy is filled only for a
+                // frame that actually composited something (`rendered` in the
+                // udev render loop), and a woken frame over a static desktop has
+                // no damage and composites nothing. The client would then wait
+                // forever — `grim` hangs on an idle screen, which is most of the
+                // time. Dropping the buffers forces a full frame, the same trick
+                // `kick_screencast_outputs` uses to keep a cast alive.
+                state.backend_data.reset_buffers(&data.output);
                 state.backend_data.request_redraw();
             }
             zwlr_screencopy_frame_v1::Request::Destroy => {}


### PR DESCRIPTION
`grim` hangs against a live session. Not intermittently — it succeeds once shortly after login, then hangs on every subsequent capture, because by then the desktop has gone static.

## Cause

A `zwlr_screencopy_frame_v1::Copy` is queued into `pending_screencopy_frames` and filled later from the render loop, gated on the frame having composited something:

```rust
let rendered = !render_frame_result.is_empty;          // udev/render.rs:2361
if rendered {
    if !pending_screencopy.is_empty() { complete_screencopy_for_output(…) }   // :2423
}
```

The `Copy` handler called `request_redraw()`, which wakes the loop — but waking is not damaging. Over a static desktop the woken frame has no damage, composites nothing, `is_empty` is true, and the copy is never fulfilled. There is no timeout, so the client blocks indefinitely.

The compositor already handles exactly this for the other capture path: `kick_screencast_outputs` (`udev/render.rs:1412`) forces a full frame via `reset_buffers` "so the screenshare blit runs without damage", precisely because a physical output only renders on damage. Screencopy never got the same treatment.

## Fix

Call `reset_buffers` on the captured output before the redraw kick, so the frame the kick produces is a full one and the copy path runs.

## Verification

Built release; `cargo fmt --all -- --check` and `cargo clippy --features default -- -D warnings` clean. Behavioural check needs a session restart on tty-udev — before: `grim` times out on an idle desktop (reproduced repeatedly across two fresh logins); after: it should return immediately. Rendering is otherwise untouched — `reset_buffers` only runs when a client has actually requested a capture.

https://claude.ai/code/session_01YVaSStMgyRMnsvSnjaVakn